### PR TITLE
Remove "and exit." when showing list of commands when running cscli

### DIFF
--- a/cmd/crowdsec-cli/main.go
+++ b/cmd/crowdsec-cli/main.go
@@ -188,7 +188,7 @@ It is meant to allow you to manage bans, parsers/scenarios/etc, api and generall
 	/*usage*/
 	var cmdVersion = &cobra.Command{
 		Use:               "version",
-		Short:             "Display version and exit.",
+		Short:             "Display version",
 		Args:              cobra.ExactArgs(0),
 		DisableAutoGenTag: true,
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
![image](https://github.com/RelativeSure/crowdsec/assets/67839982/da764492-ede0-4964-8ad7-5cb253fb2f2e)
After version it says "Display version and exit." which doesn't make sense with exit? Can it be removed?